### PR TITLE
Adding the official implementation of TRIE tokenizer for 20x speed up. 修改Tokenizer实现20x加速

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import time
 import os
 import torch
-from rwkv_pytorch import RWKV_RNN, RWKV_TOKENIZER, sample_logits
+# from rwkv_pytorch import RWKV_RNN, RWKV_TOKENIZER, sample_logits
+from rwkv_pytorch import RWKV_RNN, sample_logits
+from rwkv_tokenizer import RWKV_TOKENIZER
 
 if __name__ == '__main__':
     # 初始化模型参数

--- a/rwkv_tokenizer.py
+++ b/rwkv_tokenizer.py
@@ -85,15 +85,16 @@ class RWKV_TOKENIZER():
 
     def encode(self, src):
         if isinstance(src, str):
-            return self.encodeBytes(src.encode("utf-8"))
+            return [self.encodeBytes(src.encode("utf-8"))]
         elif isinstance(src, list):
             return [self.encodeBytes(s.encode("utf-8")) for s in src]
 
     def decode(self, tokens):
-        try:
-            return self.decodeBytes(tokens).decode('utf-8')
-        except:
-            return '\ufffd' # bad utf-8
+        return [self.decodeBytes(batch).decode('utf-8') for batch in tokens]    
+        # try:
+        #     return self.decodeBytes(tokens).decode('utf-8')
+        # except:
+        #     return '\ufffd' # bad utf-8
 
     def printTokens(self, tokens):
         for i in tokens:

--- a/rwkv_tokenizer.py
+++ b/rwkv_tokenizer.py
@@ -1,0 +1,106 @@
+########################################################################################################
+# The RWKV Language Model - https://github.com/BlinkDL/RWKV-LM
+########################################################################################################
+
+class TRIE:
+    __slots__ = tuple("ch,to,values,front".split(","))
+    to:list
+    values:set
+    def __init__(self, front=None, ch=None):
+        self.ch = ch
+        self.to = [None for ch in range(256)]
+        self.values = set()
+        self.front = front
+
+    def __repr__(self):
+        fr = self
+        ret = []
+        while(fr!=None):
+            if(fr.ch!=None):
+                ret.append(fr.ch)
+            fr = fr.front
+        return "<TRIE %s %s>"%(ret[::-1], self.values)
+    
+    def add(self, key:bytes, idx:int=0, val=None):
+        if(idx == len(key)):
+            if(val is None):
+                val = key
+            self.values.add(val)
+            return self
+        ch = key[idx]
+        if(self.to[ch] is None):
+            self.to[ch] = TRIE(front=self, ch=ch)
+        return self.to[ch].add(key, idx=idx+1, val=val)
+    
+    def find_longest(self, key:bytes, idx:int=0):
+        u:TRIE = self
+        ch:int = key[idx]
+        
+        while(u.to[ch] is not None):
+            u = u.to[ch]
+            idx += 1
+            if(u.values):
+                ret = idx, u, u.values
+            if(idx==len(key)):
+                break
+            ch = key[idx]
+        return ret
+
+class RWKV_TOKENIZER():
+    def __init__(self, file_name):
+        self.idx2token = {}
+        sorted = [] # must be already sorted
+        with open(file_name, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        for l in lines:
+            idx = int(l[:l.index(' ')])
+            x = eval(l[l.index(' '):l.rindex(' ')])
+            x = x.encode("utf-8") if isinstance(x, str) else x
+            assert isinstance(x, bytes)
+            assert len(x) == int(l[l.rindex(' '):])
+            sorted += [x]
+            self.idx2token[idx] = x
+
+        self.token2idx = {}
+        for k,v in self.idx2token.items():
+            self.token2idx[v] = int(k)
+
+        self.root = TRIE()
+        for t, i in self.token2idx.items():
+            _ = self.root.add(t, val=(t, i))
+
+    def encodeBytes(self, src:bytes):
+        idx:int = 0
+        tokens = []
+        while (idx < len(src)):
+            _idx:int = idx
+            idx, _, values = self.root.find_longest(src, idx)
+            assert(idx != _idx)
+            _, token = next(iter(values))            
+            tokens.append(token)
+        return tokens
+
+    def decodeBytes(self, tokens):
+        return b''.join(map(lambda i: self.idx2token[i], tokens))
+
+    def encode(self, src):
+        if isinstance(src, str):
+            return self.encodeBytes(src.encode("utf-8"))
+        elif isinstance(src, list):
+            return [self.encodeBytes(s.encode("utf-8")) for s in src]
+
+    def decode(self, tokens):
+        try:
+            return self.decodeBytes(tokens).decode('utf-8')
+        except:
+            return '\ufffd' # bad utf-8
+
+    def printTokens(self, tokens):
+        for i in tokens:
+            s = self.idx2token[i]
+            try:
+                s = s.decode('utf-8')
+            except:
+                pass
+            print(f'{repr(s)}{i}', end=' ')
+        print()

--- a/tokenizer_benchmark.py
+++ b/tokenizer_benchmark.py
@@ -1,0 +1,43 @@
+from rwkv_pytorch import RWKV_TOKENIZER
+from rwkv_tokenizer import RWKV_TOKENIZER as TRIE_TOKENIZER
+from icecream import ic
+import requests
+
+def timed(f):
+    import time
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        res = f(*args, **kwargs)
+        end = time.time()
+        print(f"{f.__name__} took {end-start} seconds")
+        return res
+    return wrapper
+
+
+tokenizer1 = RWKV_TOKENIZER("rwkv_vocab_v20230424.txt")
+tokenizer2 = TRIE_TOKENIZER("rwkv_vocab_v20230424.txt")
+
+
+# download the tiny shakespear dataset
+data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'
+text = requests.get(data_url).text
+
+def test_equal():
+    text = "hello world and 一些中文 to make sure the tokenizers are the same, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, @, #, $, %, ^, &, *, (, ), _, +, =, -, [, ], {, }, |, \\, ;, :, ', \", ,, <, >, ., /, ?, !, ~, `"
+    result1 = tokenizer1.encode([text])
+    result2 = tokenizer2.encode([text])
+    assert tokenizer1.encode([text] * 4) == tokenizer2.encode([text] * 4)
+
+@timed
+def test_tokenizer1():
+    tokenizer1.encode([text])
+
+@timed
+def test_tokenizer2():
+    tokenizer2.encode([text])
+
+if __name__ == '__main__':
+    
+    test_equal()
+    test_tokenizer1()
+    test_tokenizer2()


### PR DESCRIPTION
Hi, I have migrated the official TRIE_TOKENIZER from [RWKV-LM](https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v5/tokenizer/rwkv_tokenizer.py) to this repo for the TRIE tokenizer. The official trie tokenizer parses approximately 20x faster. The test code is in `tokenizer_benchmark.py`.

test_tokenizer1 took 9.673033475875854 seconds
test_tokenizer2 took 0.4087204933166504 seconds